### PR TITLE
Allow visibility option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ class Vapor
     /**
      * Store a file in S3 and return its UUID, key, and other information.
      */
-    async store(file, options = null) {
+    async store(file, options = {}) {
         const response = await axios.post('/vapor/signed-storage-url', {
             'bucket': options.bucket || '',
             'content_type': options.contentType || file.type,

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ class Vapor
             options.progress = () => {};
         }
 
-        const s3Response = await axios.put(response.data.url, file, {
+        await axios.put(response.data.url, file, {
             headers: headers,
             onUploadProgress: (progressEvent) => {
                 options.progress(progressEvent.loaded / progressEvent.total);

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,8 @@ class Vapor
         const response = await axios.post('/vapor/signed-storage-url', {
             'bucket': options.bucket || '',
             'content_type': options.contentType || file.type,
-            'expires': options.expires || ''
+            'expires': options.expires || '',
+            'visibility': options.visibility || ''
         }, {
             baseURL: options.baseURL || null
         });


### PR DESCRIPTION
This PR allow visibility option on store method, this is needed if you want to directly use uploaded file as a preview before permanent storage.

I've also fixed default options which should be an empty object, currently this code is failing if we don't pass options to store method.

There is a PHP PR too https://github.com/laravel/vapor-core/pull/21