### PR TITLE
Pass Auth Guards to Vapor SignedStorageUrlController

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,8 @@ class Vapor
             'bucket': options.bucket || '',
             'content_type': options.contentType || file.type,
             'expires': options.expires || '',
-            'visibility': options.visibility || ''
+            'visibility': options.visibility || '',
+            'guard': options.guard || ''
         }, {
             baseURL: options.baseURL || null,
             headers: options.headers || {}


### PR DESCRIPTION
Allows passing Auth Guards to Vapor SignedStorageUrlController for applications having multiple guards. (E.g. Admin, Franchisee, Customer).
I have also created a pull request on the Vapor Core repo to allow for other Auth Guards, keeping the default to env's auth.defaults.guard, so we don't introduce breaking changes for existing users of Vapor.
https://github.com/laravel/vapor-core/pull/23