### PR TITLE
Laravel Vite support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,16 @@
 const axios = require('axios')
 
-const assetUrl = process.env.MIX_VAPOR_ASSET_URL
-    ? process.env.MIX_VAPOR_ASSET_URL
-    : '';
+let assetUrlResolver = () => {
+    try {
+        return process.env.MIX_VAPOR_ASSET_URL
+            ? process.env.MIX_VAPOR_ASSET_URL
+            : '';
+    } catch (e) {
+        console.error('Unable to automatically resolve the asset URL. Use Vapor.withBaseAssetUrl() to specify it manually.')
+
+        throw e
+    }
+}
 
 class Vapor
 {
@@ -10,7 +18,14 @@ class Vapor
      * Generate the S3 URL to an application asset.
      */
     asset(path) {
-        return assetUrl + '/' + path;
+        return assetUrlResolver() + '/' + path;
+    }
+
+    /**
+     * Set the base URL for assets.
+     */
+    withBaseAssetUrl(url) {
+        assetUrlResolver = () => url ? url : ''
     }
 
     /**


### PR DESCRIPTION
This PR brings support for Vite and other future build tools. This change will have no impact on existing Mix users.

Vite users who want to use the Vapor helper to reference unbundled assets will be required to tell the package the base URL by doing the following...

```env
# file: .env
VITE_VAPOR_ASSET_URL=https://laravel.com
```

```js
// file: app.js
import Vapor from 'laravel-vapor'

Vapor.withBaseAssetUrl(import.meta.env.VITE_VAPOR_ASSET_URL)

```

```vue
<script setup>
// file: Welcome.vue

import Vapor from 'laravel-vapor'

console.log(Vapor.asset('logo.svg');
// https://laravel.com/logo.svg

</script>
```

Although it would be nice to tuck all this away, like we do with mix, there are a few issues...

1. `import.meta.env.VITE_VAPOR_ASSET_URL` does not really exist. It is a magic Vite thing, and thus when building `laravel-vapor` with microbundle, it will reduce any references to this to `void 0`.
2. Even if we could get the package to not mangle this variable, Vite only exposes the environment variables to the userland code, not the package code.

## Notes

It is important to note that the `Vapor.asset` is not actually required with Vite. Vite will prefix the URLs itself, so it is possible to build your app, deploy with Vapor, reference assets and NOT utilise the Vapor helper. If the user wants to reference unbundled assets (not built by Vite), that is the only time you MUST use the asset helper.

This will require building before we publish, of course.

See: https://github.com/laravel/vapor-docs/pull/127